### PR TITLE
WIP: Get rid of Ubuntu Polkit "Authentication required to ..." software update prompt pop-ups

### DIFF
--- a/ubuntu/20.04/install.sh
+++ b/ubuntu/20.04/install.sh
@@ -108,7 +108,7 @@ EOF
 cat > /etc/polkit-1/localauthority/50-local.d/46-allow-flatpak-update.pkla <<EOF
 [Allow Flatpak update sudo Users]
 Identity=unix-group:sudo
-Action=org.freedesktop.Flatpak.appstream-update
+Action=org.freedesktop.Flatpak.appstream-update;org.freedesktop.Flatpak.app-update;org.freedesktop.Flatpak.modify-repo
 ResultAny=no
 ResultInactive=no
 ResultActive=yes

--- a/ubuntu/20.04/install.sh
+++ b/ubuntu/20.04/install.sh
@@ -94,6 +94,16 @@ ResultInactive=no
 ResultActive=yes
 EOF
 
+# Fix "Authentication required to refresh system repositories" pop-up
+cat > /etc/polkit-1/localauthority/50-local.d/46-allow-update-repo.pkla <<EOF
+[Allow Repo Update sudo Users]
+Identity=unix-group:sudo
+Action=org.freedesktop.packagekit.system-sources-refresh
+ResultAny=no
+ResultInactive=no
+ResultActive=yes
+EOF
+
 # reconfigure the service
 systemctl daemon-reload
 systemctl start xrdp

--- a/ubuntu/20.04/install.sh
+++ b/ubuntu/20.04/install.sh
@@ -104,6 +104,16 @@ ResultInactive=no
 ResultActive=yes
 EOF
 
+# Fix flatpak update prompt "Authentication required to update information about software"
+cat > /etc/polkit-1/localauthority/50-local.d/46-allow-flatpak-update.pkla <<EOF
+[Allow Flatpak update sudo Users]
+Identity=unix-group:sudo
+Action=org.freedesktop.Flatpak.appstream-update
+ResultAny=no
+ResultInactive=no
+ResultActive=yes
+EOF
+
 # reconfigure the service
 systemctl daemon-reload
 systemctl start xrdp

--- a/ubuntu/22.04/install.sh
+++ b/ubuntu/22.04/install.sh
@@ -108,7 +108,7 @@ EOF
 cat > /etc/polkit-1/localauthority/50-local.d/46-allow-flatpak-update.pkla <<EOF
 [Allow Flatpak update sudo Users]
 Identity=unix-group:sudo
-Action=org.freedesktop.Flatpak.appstream-update
+Action=org.freedesktop.Flatpak.appstream-update;org.freedesktop.Flatpak.app-update;org.freedesktop.Flatpak.modify-repo
 ResultAny=no
 ResultInactive=no
 ResultActive=yes

--- a/ubuntu/22.04/install.sh
+++ b/ubuntu/22.04/install.sh
@@ -94,6 +94,16 @@ ResultInactive=no
 ResultActive=yes
 EOF
 
+# Fix "Authentication required to refresh system repositories" pop-up
+cat > /etc/polkit-1/localauthority/50-local.d/46-allow-update-repo.pkla <<EOF
+[Allow Repo Update sudo Users]
+Identity=unix-group:sudo
+Action=org.freedesktop.packagekit.system-sources-refresh
+ResultAny=no
+ResultInactive=no
+ResultActive=yes
+EOF
+
 # reconfigure the service
 systemctl daemon-reload
 systemctl start xrdp

--- a/ubuntu/22.04/install.sh
+++ b/ubuntu/22.04/install.sh
@@ -104,6 +104,16 @@ ResultInactive=no
 ResultActive=yes
 EOF
 
+# Fix flatpak update prompt "Authentication required to update information about software"
+cat > /etc/polkit-1/localauthority/50-local.d/46-allow-flatpak-update.pkla <<EOF
+[Allow Flatpak update sudo Users]
+Identity=unix-group:sudo
+Action=org.freedesktop.Flatpak.appstream-update
+ResultAny=no
+ResultInactive=no
+ResultActive=yes
+EOF
+
 # reconfigure the service
 systemctl daemon-reload
 systemctl start xrdp


### PR DESCRIPTION
PR get rid of Polkit prompts for software updates:
- "Authentication required to refresh system repositories." - when opening Teams for example
- "Authentication required to update information about software" - when doing `flatpak update`